### PR TITLE
Update SievePrimesAlgorithm.java booleans and exception

### DIFF
--- a/SievePrimesAlgorithm.java
+++ b/SievePrimesAlgorithm.java
@@ -12,7 +12,7 @@ public class SievePrimesAlgorithm {
 		
 		for(int p = 2; p*p <=N; p++) { 
              
-            if(prime[p] == true) { 
+            if(prime[p]) { 
                
                 for(int i = p*2; i <= N; i += p) 
                     prime[i] = false; 
@@ -34,8 +34,11 @@ public class SievePrimesAlgorithm {
 		
 		else {
 			
-			if(prime[n] == true)
-				return true;
+			try{
+				if(prime[n])
+					return true;}catch(ArrayIndexOutOfBoundsException e){
+				e.printStackTrace();
+			}
 			
 		}
 		


### PR DESCRIPTION
prime[int] == true (lines 15 & 37(now 38 with try block)) can just read prime[n] in the if statement because it is itself a boolean.

Also if someone were to enter an int greater than N they'll get an array out of bounds exception. Here it is caught and printed, but you could just return false as with anything less than or equal to 1.